### PR TITLE
Adding World Clock support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+*.iml
+.idea/
+.hubot_history

--- a/scripts/au-time.js
+++ b/scripts/au-time.js
@@ -2,7 +2,7 @@
 //   호주 시간을 알려드립니다.
 //
 // Commands:
-//   hubot 시간|time - 호주 시간을 알려 드립니다.
+//   hubot 호주시간|autime - 호주 시간을 알려 드립니다.
 
 const moment = require('moment-timezone');
 let prefix = ":koala:";
@@ -39,10 +39,10 @@ let au_time = function(msg, lang) {
 };
 
 module.exports = function(robot) {
-  robot.respond(/TIME/i, msg => au_time(msg, "en")
+  robot.respond(/(autime|AUTIME)/i, msg => au_time(msg, "en")
   );
 
-  robot.respond(/(시간|시각)/i, msg => au_time(msg, "ko")
+  robot.respond(/(호주시간|호주시각)/i, msg => au_time(msg, "ko")
   );
 
   robot.hear(/(australia|oz|au|koala|kangaroo|melbourne|sydney)( )?time/i, msg => au_time(msg, "en")

--- a/scripts/location.js
+++ b/scripts/location.js
@@ -1,0 +1,26 @@
+const googleMapUrl = 'http://maps.googleapis.com/maps/api/geocode/json';
+
+module.exports = function () {
+  /**
+   * Gets the latitude and longitude of the given location name and
+   * Returns the return val of the given callback function
+   *
+   * @param msg hubot msg
+   * @param location string
+   * @param cb callback function to be invoked with params:
+   *          hubot msg object, location string, {lat, long} object, error
+   */
+  this.getLocation = function(msg, location, cb) {
+    return msg.http(googleMapUrl).query({address: location})
+      .get()((err, res, body) => {
+        try {
+          body = JSON.parse(body);
+          var coords = body.results[0].geometry.location;
+        } catch (err) {
+          err = `🐨 ${location}... 어딘지 모르겠어요.`;
+          return cb(msg, null, null, err);
+        }
+        return cb(msg, location, coords, err);
+      });
+    };
+};

--- a/scripts/time.js
+++ b/scripts/time.js
@@ -1,0 +1,42 @@
+// Description:
+//   세계시간을 알려드립니다
+// Commands:
+//   hubot 장소이름 시간|time - 세계시간을 알려 드립니다
+
+const googleTimezoneUrl = 'https://maps.googleapis.com/maps/api/timezone/json';
+const location = require('./location');
+const moment = require('moment-timezone');
+
+let getLocation = new location().getLocation;
+
+let lookupTime = function(msg, location, coords, err) {
+  if (err) {
+    return msg.send(err);
+  }
+
+  let timestamp = new Date().getTime() / 1000;
+  let locationString = `${coords.lat},${coords.lng}`;
+
+  return msg.http(googleTimezoneUrl).query({location: locationString, timestamp: timestamp})
+    .get()((err, res, body) => {
+      try {
+        body = JSON.parse(body);
+      } catch (err) {
+        return msg.send(`🐨 ${location}...어딘지 모르겠어요.`);
+      }
+
+      // Request failed for some reasons: Denied, Over Query Limit, Zero Result, or Unknown
+      if (body.status !== 'OK') {
+        return msg.send(`🐨 ... 오류가 발생하였습니다 - ${body.status}`);
+      }
+
+      let time = moment.tz(body.timeZoneId).format('h:mm a');
+      return msg.send(`🐨 ${location}의 현재시간은 ${time} 입니다. (${body.timeZoneName} Zone)`);
+    });
+};
+
+module.exports = function(robot) {
+  robot.respond(/(.*)\s(time|시간)/i, function (msg) {
+    return getLocation(msg, msg.match[1], lookupTime);
+  });
+};


### PR DESCRIPTION
#1
- World Clock is supported
  1. gets the longitude/latitude of the location name (using Google Geocoding API) 
  2. gets the timezone of the longitude/latitude (using Google Timezone API)
  3. prints out the local time 
- The original 시간|Time is changed to 호주시간|autime
- No Google API Key is required
