### PR TITLE
fix bug

### DIFF
--- a/scripts/location.js
+++ b/scripts/location.js
@@ -16,7 +16,7 @@ module.exports = function () {
     const query = {address: location}
     if (sensor) { query.sensor = true }
 
-    return msg.http(googleMapUrl).query()
+    return msg.http(googleMapUrl).query(query)
       .get()((err, res, body) => {
         try {
           body = JSON.parse(body);


### PR DESCRIPTION
http.query() 에 파라미터가 빠져있었습니다.

koalabot 시간 서울  시 
2017-08-30T09:00:27.586462+00:00 app[web.1]: [Wed Aug 30 2017 09:00:27 GMT+0000 (UTC)] ERROR TypeError: Cannot convert undefined or null to object
2017-08-30T09:00:27.586478+00:00 app[web.1]:     at extend (/app/node_modules/scoped-http-client/src/index.js:267:10)
2017-08-30T09:00:27.586479+00:00 app[web.1]:     at ScopedClient.query (/app/node_modules/scoped-http-client/src/index.js:162:7)
2017-08-30T09:00:27.586480+00:00 app[web.1]:     at getLocation (/app/scripts/location.js:19:35)
2017-08-30T09:00:27.586481+00:00 app[web.1]:     at TextListener.callback (/app/scripts/time.js:40:12)
2017-08-30T09:00:27.586481+00:00 app[web.1]:     at /app/node_modules/hubot/src/listener.coffee:65:12
2017-08-30T09:00:27.586482+00:00 app[web.1]:     at allDone (/app/node_modules/hubot/src/middleware.coffee:44:37)
2017-08-30T09:00:27.586483+00:00 app[web.1]:     at /app/node_modules/hubot/node_modules/async/lib/async.js:274:13
2017-08-30T09:00:27.586483+00:00 app[web.1]:     at Object.async.eachSeries (/app/node_modules/hubot/node_modules/async/lib/async.js:142:20)
2017-08-30T09:00:27.586484+00:00 app[web.1]:     at Object.async.reduce (/app/node_modules/hubot/node_modules/async/lib/async.js:268:15)
2017-08-30T09:00:27.586485+00:00 app[web.1]:     at /app/node_modules/hubot/src/middleware.coffee:49:13
2017-08-30T09:00:27.586485+00:00 app[web.1]:     at _combinedTickCallback (internal/process/next_tick.js:73:7)
2017-08-30T09:00:27.586486+00:00 app[web.1]:     at process._tickCallback (internal/process/next_tick.js:104:9)

와 같은 에러가 발생했습니다.

감사합니다.