### PR TITLE
암호화폐 시세확인하는 coin.js 추가

### DIFF
--- a/scripts/coin.js
+++ b/scripts/coin.js
@@ -1,0 +1,46 @@
+var request = require('request');
+
+const getPrice = (coinType, cb)=>{
+	const coinNameToParam = {
+		'bitcoin': 'btc_krw',
+		'ethereum': 'eth_krw',
+		'ripple': 'xrp_krw',
+		'bitcoincash': 'bch_krw'
+	}
+
+	const url =`https://api.korbit.co.kr/v1/ticker/detailed?currency_pair=${coinNameToParam[coinType]}`
+	request.get({
+		url:url,
+		headers:{
+			'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.101 Safari/537.36'
+		}
+	}, (err,resp,res)=>{
+		if (err) {
+			return cb(err, null);
+		} else if (resp.statusCode !== 200){
+       	    return cb('시세를 못찾겠네여...', null);
+		}else {
+		    let result = JSON.parse(res);
+	
+    	    if( !result || !result.bid || !result.ask){
+        	    return cb('시세를 못찾겠네여...', null);
+	        } else {
+				let message = `현재 ${coinType}의 최종거래가격은 ${result.last}원 매수가격은 ${result.bid}원 매도가격은 ${result.ask}원 입니다 감사합니다`
+	    	    return cb(null, message)
+			}
+		}
+	});    
+};
+
+module.exports = function(robot){
+	return robot.respond(/coin (.*)/i, function(msg){
+		let coinType = msg.match[1];
+		getPrice(coinType, (err, result)=>{
+			if( err ){
+				return msg.send(err);
+			} else {
+				return msg.send(result);
+			}
+		});
+	})
+}

--- a/scripts/coin.js
+++ b/scripts/coin.js
@@ -24,7 +24,7 @@ const getPrice = (coinType, cb)=>{
 			let result = JSON.parse(res);
 	
 			if ( !result || !result.bid || !result.ask) {
-        		return cb('시세를 못찾겠네여...', null);
+				return cb('시세를 못찾겠네여...', null);
 			} else {
 				let message = `현재 ${coinType}의 최종거래가격은 ${result.last}원 매수가격은 ${result.bid}원 매도가격은 ${result.ask}원 입니다 감사합니다`
 				return cb(null, message)

--- a/scripts/coin.js
+++ b/scripts/coin.js
@@ -9,6 +9,7 @@ const getPrice = (coinType, cb)=>{
 	}
 
 	const url =`https://api.korbit.co.kr/v1/ticker/detailed?currency_pair=${coinNameToParam[coinType]}`
+
 	request.get({
 		url:url,
 		headers:{
@@ -18,15 +19,15 @@ const getPrice = (coinType, cb)=>{
 		if (err) {
 			return cb(err, null);
 		} else if (resp.statusCode !== 200){
-       	    return cb('시세를 못찾겠네여...', null);
-		}else {
-		    let result = JSON.parse(res);
+			return cb('시세를 못찾겠네여...', null);
+		} else {
+			let result = JSON.parse(res);
 	
-    	    if( !result || !result.bid || !result.ask){
-        	    return cb('시세를 못찾겠네여...', null);
-	        } else {
+			if ( !result || !result.bid || !result.ask) {
+        		return cb('시세를 못찾겠네여...', null);
+			} else {
 				let message = `현재 ${coinType}의 최종거래가격은 ${result.last}원 매수가격은 ${result.bid}원 매도가격은 ${result.ask}원 입니다 감사합니다`
-	    	    return cb(null, message)
+				return cb(null, message)
 			}
 		}
 	});    


### PR DESCRIPTION
암호화폐 시세를 확인하는 coin.js 를 추가하였습니다.
@koalabot coin bitcoin 과 같은 형태로 호출합니다.

현재 지원하는건 bitcoin, ethereum, ripple, bitcoincash 입니다

코빗(https://www.korbit.co.kr/) 에서 제공하는 api 를 통해 시세를 확인합니다. 

api를 위한 토큰은 따로 필요하지않습니다. 
(https://apidocs.korbit.co.kr/#exchange:-public)

weird-coin 과 같은 암호화폐관련 채널이 생겨서 쓰일 일이 생기지않을까 해서 만들어보았습니다.

감사합니다.